### PR TITLE
fixed size_type = uint64_t for binary stability

### DIFF
--- a/include/decodeless/offset_ptr.hpp
+++ b/include/decodeless/offset_ptr.hpp
@@ -3,6 +3,7 @@
 #pragma once
 
 #include <cstddef>
+#include <cstdint>
 #include <type_traits>
 
 #ifndef ENABLE_OFFSET_PTR_TRANSLATE
@@ -16,7 +17,7 @@ template <class T> class offset_ptr {
 public:
     using value_type = T;
     using offset_type = std::ptrdiff_t;
-    using size_type = std::size_t;
+    using size_type = std::uint64_t;
     offset_ptr() = default;
     ~offset_ptr() noexcept = default;
     offset_ptr(const offset_ptr& other) : offset_ptr(other.get()) {}

--- a/include/decodeless/offset_span.hpp
+++ b/include/decodeless/offset_span.hpp
@@ -2,6 +2,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <decodeless/offset_ptr.hpp>
 #include <type_traits>
 
@@ -20,10 +21,12 @@
 namespace decodeless {
 
 // std::span equivalent but implemented with an offset_ptr
+// Uses a fixed x64 size type for binary stability in files. May conflict with
+// std::span conversion on x32 systems
 template <class T> class offset_span {
 public:
     using value_type = T;
-    using size_type = std::size_t;
+    using size_type = std::uint64_t;
     using iterator = T*;
     using reference = T&;
     offset_span() = default;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated size representation in the `offset_ptr` and `offset_span` classes to ensure consistent and portable handling of object sizes across different platforms.

- **Bug Fixes**
	- Enhanced binary stability for size-related operations, particularly for x64 systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->