### PR TITLE
offset_span::empty() and nodiscard

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -1,7 +1,7 @@
 # Multiple platforms and compilers
 name: build and test
 
-on: [push, pull_request]
+on: pull_request
 
 jobs:
   build:
@@ -9,18 +9,17 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Cannot use ubuntu-latest with clang due to github bug: https://github.com/actions/runner-images/discussions/9446
-        os: [ubuntu-20.04, ubuntu-latest, windows-latest]
+        os: [ubuntu-24.04, windows-latest]
         build_type: [Debug, Release]
         c_compiler: [gcc, clang, cl]
         include:
           - os: windows-latest
             c_compiler: cl
             cpp_compiler: cl
-          - os: ubuntu-latest
+          - os: ubuntu-24.04
             c_compiler: gcc
             cpp_compiler: g++
-          - os: ubuntu-20.04
+          - os: ubuntu-24.04
             c_compiler: clang
             cpp_compiler: clang++
         exclude:
@@ -28,14 +27,8 @@ jobs:
             c_compiler: gcc
           - os: windows-latest
             c_compiler: clang
-          - os: ubuntu-latest
+          - os: ubuntu-24.04
             c_compiler: cl
-          - os: ubuntu-latest
-            c_compiler: clang
-          - os: ubuntu-20.04
-            c_compiler: cl
-          - os: ubuntu-20.04
-            c_compiler: gcc
 
     steps:
     - uses: actions/checkout@v3

--- a/include/decodeless/offset_ptr.hpp
+++ b/include/decodeless/offset_ptr.hpp
@@ -7,7 +7,7 @@
 #include <type_traits>
 
 #ifndef ENABLE_OFFSET_PTR_TRANSLATE
-#define ENABLE_OFFSET_PTR_TRANSLATE 0
+    #define ENABLE_OFFSET_PTR_TRANSLATE 0
 #endif
 
 namespace decodeless {
@@ -23,7 +23,7 @@ public:
     offset_ptr(const offset_ptr& other) : offset_ptr(other.get()) {}
     offset_ptr(offset_ptr&& other) noexcept : offset_ptr(other.get()) {}
     offset_ptr(T* ptr) { set(ptr); }
-    T* get() const {
+    [[nodiscard]] T* get() const {
         return m_offset == NullValue ? nullptr
                                      : reinterpret_cast<T*>(base_() + m_offset);
     }
@@ -32,10 +32,10 @@ public:
                        ? NullValue
                        : (reinterpret_cast<offset_type>(ptr) - base_());
     }
-    bool operator==(const offset_ptr& other) const {
+    [[nodiscard]] bool operator==(const offset_ptr& other) const {
         return get() == other.get();
     }
-    bool operator!=(const offset_ptr& other) const {
+    [[nodiscard]] bool operator!=(const offset_ptr& other) const {
         return get() != other.get();
     }
     offset_ptr& operator=(const offset_ptr& other) {
@@ -46,26 +46,29 @@ public:
         set(other.get());
         return *this;
     }
-    T& operator[](size_type pos) const { return get()[pos]; }
-    T& operator*() const { return *get(); }
-    T* operator->() const { return get(); }
-    operator bool() const { return m_offset != NullValue; }
+    [[nodiscard]] T& operator[](size_type pos) const { return get()[pos]; }
+    [[nodiscard]] T& operator*() const { return *get(); }
+    [[nodiscard]] T* operator->() const { return get(); }
+    [[nodiscard]] operator bool() const { return m_offset != NullValue; }
 
-    #if ENABLE_OFFSET_PTR_TRANSLATE
-    T* translate(const void* srcBase, void* dstBase) const {
+#if ENABLE_OFFSET_PTR_TRANSLATE
+    [[nodiscard]] T* translate(const void* srcBase, void* dstBase) const {
         return reinterpret_cast<T*>(reinterpret_cast<uintptr_t>(get()) -
                                     reinterpret_cast<uintptr_t>(srcBase) +
                                     reinterpret_cast<uintptr_t>(dstBase));
     }
-    const T* translate(const void* srcBase, const void* dstBase) const {
+    [[nodiscard]] const T* translate(const void* srcBase,
+                                     const void* dstBase) const {
         return reinterpret_cast<const T*>(reinterpret_cast<uintptr_t>(get()) -
                                           reinterpret_cast<uintptr_t>(srcBase) +
                                           reinterpret_cast<uintptr_t>(dstBase));
     }
-    #endif
+#endif
 
 private:
-    offset_type base_() const { return reinterpret_cast<offset_type>(this); }
+    [[nodiscard]] offset_type base_() const {
+        return reinterpret_cast<offset_type>(this);
+    }
 
     // Considered null when the offset is one byte, to allow pointing to self.
     static const offset_type NullValue = 1;

--- a/include/decodeless/offset_span.hpp
+++ b/include/decodeless/offset_span.hpp
@@ -15,7 +15,7 @@
 #endif
 
 #ifndef ENABLE_OFFSET_PTR_TRANSLATE
-#define ENABLE_OFFSET_PTR_TRANSLATE 0
+    #define ENABLE_OFFSET_PTR_TRANSLATE 0
 #endif
 
 namespace decodeless {
@@ -34,15 +34,16 @@ public:
 
 #ifdef __cpp_lib_span
     operator std::span<T>() const { return {m_data.get(), m_size}; }
-    std::span<T> subspan(size_type offset) const {
+    [[nodiscard]] std::span<T> subspan(size_type offset) const {
         return {m_data.get() + offset, m_size - offset};
     }
     #if ENABLE_OFFSET_PTR_TRANSLATE
-    std::span<T> translate(const void* srcBase, void* dstBase) const {
+    [[nodiscard]] std::span<T> translate(const void* srcBase,
+                                         void* dstBase) const {
         return {m_data.translate(srcBase, dstBase), m_size};
     }
-    std::span<const T> translate(const void* srcBase,
-                                 const void* dstBase) const {
+    [[nodiscard]] std::span<const T> translate(const void* srcBase,
+                                               const void* dstBase) const {
         return {m_data.translate(srcBase, dstBase), m_size};
     }
     #endif
@@ -59,13 +60,16 @@ public:
     }
 #endif
 
-    iterator data() const { return m_data.get(); }
-    const size_type& size() const { return m_size; }
-    iterator begin() const { return data(); }
-    iterator end() const { return data() + m_size; }
-    reference operator[](size_type pos) const { return begin()[pos]; }
-    reference front() const { return *begin(); }
-    reference back() const { return *std::prev(end()); }
+    [[nodiscard]] iterator data() const { return m_data.get(); }
+    [[nodiscard]] const size_type& size() const { return m_size; }
+    [[nodiscard]] bool empty() const { return size() == 0; }
+    [[nodiscard]] iterator begin() const { return data(); }
+    [[nodiscard]] iterator end() const { return data() + m_size; }
+    [[nodiscard]] reference operator[](size_type pos) const {
+        return begin()[pos];
+    }
+    [[nodiscard]] reference front() const { return *begin(); }
+    [[nodiscard]] reference back() const { return *std::prev(end()); }
 
 private:
     offset_ptr<T> m_data;
@@ -73,7 +77,8 @@ private:
 };
 
 template <typename Range>
-offset_span(Range&& range) -> offset_span<std::remove_reference_t<
-    decltype(*std::ranges::data(std::forward<Range>(range)))>>;
+offset_span(Range&& range)
+    -> offset_span<std::remove_reference_t<
+        decltype(*std::ranges::data(std::forward<Range>(range)))>>;
 
 } // namespace decodeless

--- a/test/src/test_offset_span.cpp
+++ b/test/src/test_offset_span.cpp
@@ -10,6 +10,15 @@ TEST(Span, ConstructorDefault) {
     offset_span<int> span;
     EXPECT_EQ(nullptr, span.data());
     EXPECT_EQ(0, span.size());
+    EXPECT_TRUE(span.empty());
+}
+
+TEST(Span, ConstructorEmpty) {
+    int i[3];
+    offset_span<int> span(i, 0);
+    EXPECT_EQ(i, span.data());
+    EXPECT_EQ(0, span.size());
+    EXPECT_TRUE(span.empty());
 }
 
 TEST(Span, ConstructorPtrSize) {
@@ -17,6 +26,7 @@ TEST(Span, ConstructorPtrSize) {
     offset_span<int> span(i, std::size(i));
     EXPECT_EQ(i, span.data());
     EXPECT_EQ(3, span.size());
+    EXPECT_FALSE(span.empty());
 }
 
 TEST(Span, ConstructorSpan) {
@@ -28,6 +38,7 @@ TEST(Span, ConstructorSpan) {
     span = stdspan;
     EXPECT_EQ(i, span.data());
     EXPECT_EQ(3, span.size());
+    EXPECT_FALSE(span.empty());
 }
 
 TEST(Span, ConstructorSpanConst) {
@@ -39,6 +50,7 @@ TEST(Span, ConstructorSpanConst) {
     span = stdspan;
     EXPECT_EQ(i, span.data());
     EXPECT_EQ(3, span.size());
+    EXPECT_FALSE(span.empty());
 }
 
 TEST(Span, ConstructorRange) {
@@ -46,6 +58,7 @@ TEST(Span, ConstructorRange) {
     offset_span<int> span(i);
     EXPECT_EQ(i, span.data());
     EXPECT_EQ(3, span.size());
+    EXPECT_FALSE(span.empty());
 }
 
 TEST(Span, ConstructorVector) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced `[[nodiscard]]` attributes to multiple functions in the `offset_ptr` and `offset_span` classes, promoting better handling of return values.
	- Added new functions in `offset_span` that also utilize the `[[nodiscard]]` attribute for enhanced safety and usability.
	- Updated GitHub Actions workflow to trigger builds only on pull requests, optimizing the CI/CD process.

- **Bug Fixes**
	- Improved code readability and maintainability by adjusting formatting and indentation of macro definitions.
  
- **Tests**
	- Enhanced testing suite for `offset_span` with new test cases and assertions to verify the behavior of constructors and the `empty()` method.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->